### PR TITLE
Add eth2 validator key derivation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,25 +13,48 @@ export function generateRandomSecretKey(entropy?: Buffer): Buffer {
   if(entropy) {
     ikm = Buffer.concat([entropy, ikm]);
   }
-  return deriveKey(ikm, null);
+  return deriveKeyFromEntropy(ikm, null);
 }
 
 export function mnemonicToSecretKey(mnemonic: string, path: string | null = "m/12381/3600/0/0"): Buffer {
   assert(validateMnemonic(mnemonic), "invalid mnemonic");
   const ikm = Buffer.from(mnemonicToSeedSync(mnemonic));
-  return deriveKey(ikm, path);
+  return deriveKeyFromEntropy(ikm, path);
 }
 
 /**
  * Derive child key from seed and path.
  * If path is omitted seed will be converted to valid secret key
- * @param seed
- * @param path
  */
-export function deriveKey(seed: Buffer, path: string | null = "m/12381/3600/0/0"): Buffer {
-  const masterKey = deriveMasterSK(Buffer.from(seed));
+export function deriveKeyFromEntropy(entropy: Buffer, path: string | null = "m/12381/3600/0/0"): Buffer {
+  const masterKey = deriveMasterSK(Buffer.from(entropy));
   if(path) {
-    return deriveChildSKMultiple(masterKey, pathToIndices(path));
+    return deriveKeyFromMaster(masterKey, path);
   }
   return masterKey;
+}
+
+/**
+ * Derive a child key from a master secret key
+ * @param masterKey master secret key
+ * @param path hd path to child
+ */
+export function deriveKeyFromMaster(masterKey: Buffer, path: string): Buffer {
+  return deriveChildSKMultiple(masterKey, pathToIndices(path));
+}
+
+export interface IEth2ValidatorKeys {
+  withdrawal: Buffer;
+  signing: Buffer;
+}
+
+/**
+ * Derive Eth2 validator keys from a single master key
+ * @param masterKey master secret key
+ */
+export function deriveEth2ValidatorKeys(masterKey: Buffer, validatorIndex: number): IEth2ValidatorKeys {
+  return {
+    withdrawal: deriveKeyFromMaster(masterKey, `m/12381/3600/${validatorIndex}/0`),
+    signing: deriveKeyFromMaster(masterKey, `m/12381/3600/${validatorIndex}/0/0`),
+  };
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,4 @@
-import {mnemonicToSecretKey, generateRandomSecretKey, deriveKey} from "../src";
+import {mnemonicToSecretKey, generateRandomSecretKey, deriveKeyFromEntropy} from "../src";
 import {expect} from "chai";
 import {generateMnemonic} from "bip39";
 
@@ -42,16 +42,16 @@ describe("private key from seed", function () {
 
   it("should generate using default path", function () {
     const seed = Buffer.alloc(32, 1);
-    const key = deriveKey(seed);
-    const key1 = deriveKey(seed);
+    const key = deriveKeyFromEntropy(seed);
+    const key1 = deriveKeyFromEntropy(seed);
     expect(key).to.not.be.null;
     expect(key.toString("hex")).to.be.equal(key1.toString("hex"));
   });
 
   it("should generate using given path", function () {
     const seed = Buffer.alloc(32, 2);
-    const key = deriveKey(seed, "m/12381/3600/0/1");
-    const key1 = deriveKey(seed, "m/12381/3600/0/2");
+    const key = deriveKeyFromEntropy(seed, "m/12381/3600/0/1");
+    const key1 = deriveKeyFromEntropy(seed, "m/12381/3600/0/2");
     expect(key).to.not.be.null;
     expect(key.toString("hex")).to.not.be.equal(key1.toString("hex"));
   });


### PR DESCRIPTION
- Add `deriveEth2ValidatorKeys` which create withdrawal and signing keys from a master key.
- Add `deriveKeyFromMaster` to support :arrow_up:  and :arrow_down: 
- Rename `deriveKey` to `deriveKeyFromEntropy` to avoid confusion