### PR TITLE
Default optional paths to undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,20 +13,26 @@ export function generateRandomSecretKey(entropy?: Buffer): Buffer {
   if(entropy) {
     ikm = Buffer.concat([entropy, ikm]);
   }
-  return deriveKeyFromEntropy(ikm, null);
+  return deriveKeyFromEntropy(ikm);
 }
 
-export function mnemonicToSecretKey(mnemonic: string, path: string | null = "m/12381/3600/0/0"): Buffer {
+/**
+ * Derive a key from a BIP39 mnemonic seed and optionally a path.
+ * If path is included, the derived key will be the child secret key at that path,
+ * otherwise, the derived key will be the master secret key
+ */
+export function mnemonicToSecretKey(mnemonic: string, path?: string): Buffer {
   assert(validateMnemonic(mnemonic), "invalid mnemonic");
   const ikm = Buffer.from(mnemonicToSeedSync(mnemonic));
   return deriveKeyFromEntropy(ikm, path);
 }
 
 /**
- * Derive child key from seed and path.
- * If path is omitted seed will be converted to valid secret key
+ * Derive a key from entropy and optionally a path.
+ * If path is included, the derived key will be the child secret key at that path,
+ * otherwise, the derived key will be the master secret key
  */
-export function deriveKeyFromEntropy(entropy: Buffer, path: string | null = "m/12381/3600/0/0"): Buffer {
+export function deriveKeyFromEntropy(entropy: Buffer, path?: string): Buffer {
   const masterKey = deriveMasterSK(Buffer.from(entropy));
   if(path) {
     return deriveKeyFromMaster(masterKey, path);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -20,7 +20,7 @@ describe("random private key", function () {
 
 describe("private key from mnemonic", function () {
 
-  it("should generate using default path", function () {
+  it("should generate master key", function () {
     const mnemonic = generateMnemonic();
     const key = mnemonicToSecretKey(mnemonic);
     const key1 = mnemonicToSecretKey(mnemonic);
@@ -38,9 +38,9 @@ describe("private key from mnemonic", function () {
 
 });
 
-describe("private key from seed", function () {
+describe("private key from entropy", function () {
 
-  it("should generate using default path", function () {
+  it("should generate master key", function () {
     const seed = Buffer.alloc(32, 1);
     const key = deriveKeyFromEntropy(seed);
     const key1 = deriveKeyFromEntropy(seed);
@@ -48,7 +48,7 @@ describe("private key from seed", function () {
     expect(key.toString("hex")).to.be.equal(key1.toString("hex"));
   });
 
-  it("should generate using given path", function () {
+  it("should generate child key using given path", function () {
     const seed = Buffer.alloc(32, 2);
     const key = deriveKeyFromEntropy(seed, "m/12381/3600/0/1");
     const key1 = deriveKeyFromEntropy(seed, "m/12381/3600/0/2");


### PR DESCRIPTION
Relies on #7 
Change the default values of `path` in `deriveKeyFromEntropy` and `mnemonicToSecretKey` to `undefined`.
Add documentation strings to `deriveKeyFromEntropy` and `mnemonicToSecretKey`.

This simplifies the typing of the inputs of these functions, and should result in more intuitive use.