### PR TITLE
v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chainsafe/bls-keygen",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Typescript key management tool that works in the browser",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",


### PR DESCRIPTION
Breaking changes:

`deriveKey`
- renamed `deriveKeyFromEntropy`
- default path to `undefined` (master key)

`mnemonicToSecretKey`
- renamed `deriveKeyFromMnemonic`
- default path to `undefined` (master key)

Additions:
- add `deriveKeyFromMaster` to derive a child key from a master key
- add `deriveEth2ValidatorKeys` to derive eth2 signing and withdrawal keys from a master key