### PR TITLE
Add eth2ValidatorPaths utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,12 +55,26 @@ export interface IEth2ValidatorKeys {
 }
 
 /**
+ * Return Eth2 validator HD paths
+ */
+export function eth2ValidatorPaths(validatorIndex: number): {
+  withdrawal: string;
+  signing: string;
+} {
+  return {
+    withdrawal: `m/12381/3600/${validatorIndex}/0`,
+    signing: `m/12381/3600/${validatorIndex}/0/0`,
+  };
+}
+
+/**
  * Derive Eth2 validator secret keys from a single master secret key
  * @param masterKey master secret key
  */
 export function deriveEth2ValidatorKeys(masterKey: Buffer, validatorIndex: number): IEth2ValidatorKeys {
+  const paths = eth2ValidatorPaths(validatorIndex);
   return {
-    withdrawal: deriveKeyFromMaster(masterKey, `m/12381/3600/${validatorIndex}/0`),
-    signing: deriveKeyFromMaster(masterKey, `m/12381/3600/${validatorIndex}/0/0`),
+    withdrawal: deriveKeyFromMaster(masterKey, paths.withdrawal),
+    signing: deriveKeyFromMaster(masterKey, paths.signing),
   };
 }


### PR DESCRIPTION
Split out the eth2ValidatorPaths function to return the hd paths for validators given a validator index
Useful for creating keystores, when the path is useful metadata to store.