### PR TITLE
feat: speed up derivation of signing key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 15]
+        node: [20, 22]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "test": "yarn run test:node && yarn run test:web",
         "test:node": "mocha -r ts-node/register test/**/*.spec.ts ",
-        "test:web": "karma start",
+        "test:web": "NODE_OPTIONS=--openssl-legacy-provider karma start",
         "clean": "rm -rf lib",
         "lint": "eslint --ext .ts src/",
         "check-types": "tsc --noEmit",


### PR DESCRIPTION
Speed up derivation of signing key by extending from withdrawal key.

Also added flag so that karma runs with current node (v22.4.1) as legacy openssl is required for the karma version

Needed to update CI to use current versions of node (20, 22)